### PR TITLE
feat(iterable_test): Add test about handler openedNotificationHandler

### DIFF
--- a/test/iterable_flutter_test.dart
+++ b/test/iterable_flutter_test.dart
@@ -89,4 +89,32 @@ void main() {
       isMethodCall('signOut', arguments: null),
     ]);
   });
+
+  test("openedNotificationHandler", () async {
+    IterableFlutter.initialize(
+      apiKey: apiKey,
+      pushIntegrationName: pushIntegrationName,
+    );
+
+    var pushData;
+    final contentBody = "Test body push";
+    final keyBody = "body";
+
+    IterableFlutter.setNotificationOpenedHandler((openedResultMap) {
+      pushData = openedResultMap;
+    });
+
+    await ServicesBinding.instance?.defaultBinaryMessenger
+        .handlePlatformMessage(
+            'iterable_flutter',
+            StandardMethodCodec().encodeMethodCall(
+              MethodCall(
+                'openedNotificationHandler',
+                {keyBody: contentBody},
+              ),
+            ),
+            (ByteData? data) {});
+
+    expect(contentBody, pushData[keyBody]);
+  });
 }


### PR DESCRIPTION
This PR a test about openedNotificationHandler.

* A method is use to simulate the call from native : [example](https://github.com/flutter/flutter/issues/63465#issuecomment-899379305)
* And test handler **openedNotificationHandler**
