### PR TITLE
feat(open_push_app_close):  Fix when open app from a push notification.

### DIFF
--- a/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
@@ -73,6 +73,10 @@ class IterableFlutterPlugin : FlutterPlugin, MethodCallHandler {
         IterableApi.getInstance().disablePush()
         result.success(null)
       }
+      "checkRecentNotification" -> {
+        notifyPushNotificationOpened()
+        result.success(null)
+      }
       else -> {
         result.notImplemented()
       }
@@ -88,7 +92,7 @@ class IterableFlutterPlugin : FlutterPlugin, MethodCallHandler {
         false
       }
 
-    if (activeLogDebug){
+    if (activeLogDebug) {
       configBuilder.setLogLevel(Log.DEBUG)
     }
 
@@ -101,18 +105,17 @@ class IterableFlutterPlugin : FlutterPlugin, MethodCallHandler {
 
   private fun notifyPushNotificationOpened() {
     val bundleData = IterableApi.getInstance().payloadData
-    val pushData = clearPushData(bundleData)
-    channel.invokeMethod("openedNotificationHandler", pushData)
+
+    bundleData?.let {
+      val pushData = clearPushData(it)
+      channel.invokeMethod("openedNotificationHandler", pushData)
+    }
   }
 
-  private fun clearPushData(bundleData: Bundle?): Map<String, Any?> {
+  private fun clearPushData(bundleData: Bundle): Map<String, Any?> {
 
-    return bundleData?.let { bundle ->
-      val mapPushData = bundleToMap(bundle)
-      return buildPushDataMap(mapPushData)
-    } ?: run {
-      return mapOf()
-    }
+    val mapPushData = bundleToMap(bundleData)
+    return buildPushDataMap(mapPushData)
   }
 
   private fun buildPushDataMap(mapPushData: Map<String, Any?>): Map<String, Any?> {
@@ -123,19 +126,15 @@ class IterableFlutterPlugin : FlutterPlugin, MethodCallHandler {
     )
   }
 
-  private fun bundleToMap(extras: Bundle?): Map<String, String?> {
-    return extras?.let { bundle ->
-      val map: MutableMap<String, String?> = HashMap()
-      val keySetValue = bundle.keySet()
-      val iterator: Iterator<String> = keySetValue.iterator()
-      while (iterator.hasNext()) {
-        val key = iterator.next()
-        map[key] = bundle.getString(key)
-      }
-      return map
-    } ?: run {
-      return mapOf()
-    }
+  private fun bundleToMap(extras: Bundle): Map<String, String?> {
 
+    val map: MutableMap<String, String?> = HashMap()
+    val keySetValue = extras.keySet()
+    val iterator: Iterator<String> = keySetValue.iterator()
+    while (iterator.hasNext()) {
+      val key = iterator.next()
+      map[key] = extras.getString(key)
+    }
+    return map
   }
 }

--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -46,9 +46,14 @@ class IterableFlutter {
     await _channel.invokeMethod('signOut');
   }
 
+  static Future<void> checkRecentNotification() async {
+    await _channel.invokeMethod('checkRecentNotification');
+  }
+
   // ignore: use_setters_to_change_properties
   static void setNotificationOpenedHandler(OpenedNotificationHandler handler) {
     _onOpenedNotification = handler;
+    checkRecentNotification();
   }
 
   static Future<dynamic> nativeMethodCallHandler(MethodCall methodCall) async {
@@ -57,7 +62,7 @@ class IterableFlutter {
     switch (methodCall.method) {
       case "openedNotificationHandler":
         _onOpenedNotification?.call(arguments);
-        return "This data from flutter.....";
+        return "This data from navitve.....";
       default:
         return "Nothing";
     }

--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -62,7 +62,7 @@ class IterableFlutter {
     switch (methodCall.method) {
       case "openedNotificationHandler":
         _onOpenedNotification?.call(arguments);
-        return "This data from navitve.....";
+        return "This data from native.....";
       default:
         return "Nothing";
     }

--- a/test/iterable_flutter_test.dart
+++ b/test/iterable_flutter_test.dart
@@ -35,6 +35,8 @@ void main() {
           return null;
         case 'signOut':
           return null;
+        case 'checkRecentNotification':
+          return null;
         default:
           return null;
       }
@@ -95,6 +97,13 @@ void main() {
     await IterableFlutter.signOut();
     expect(calledMethod, <Matcher>[
       isMethodCall('signOut', arguments: null),
+    ]);
+  });
+
+  test('checkRecentNotification', () async {
+    IterableFlutter.setNotificationOpenedHandler((openedResultMap) {});
+    expect(calledMethod, <Matcher>[
+      isMethodCall('checkRecentNotification', arguments: null),
     ]);
   });
 


### PR DESCRIPTION
### Summary 

When a push arrived and the app is completely closed, in the client app as it has several initiators, the `setNotificationOpenedHandler` listener does not work correctly since due to that delay in setup, the push did not reach that handler, therefore, the data cloud not be processed. 

This PR :

- Support in swift for check if open from a notification
- Support in Android for check if open from a notification
- `Iterable_flutter`  new method channel as `checkRecentNotification`
- New test for `checkRecentNotification`
