### PR TITLE
fix(android sanitize): Support value in String and Integer

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,10 @@ android {
     defaultConfig {
         minSdkVersion 16
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -40,4 +44,7 @@ dependencies {
 
     implementation 'com.iterable:iterableapi:3.3.1'
     implementation 'com.google.firebase:firebase-messaging:22.0.0'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.json:json:20210307'
+
 }

--- a/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
@@ -127,7 +127,7 @@ class IterableFlutterPlugin : FlutterPlugin, MethodCallHandler {
       val key = iterator.next()
       map[key] = extras[key]
     }
-    
+
     return map
   }
 }

--- a/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
@@ -115,26 +115,19 @@ class IterableFlutterPlugin : FlutterPlugin, MethodCallHandler {
   private fun clearPushData(bundleData: Bundle): Map<String, Any?> {
 
     val mapPushData = bundleToMap(bundleData)
-    return buildPushDataMap(mapPushData)
+    return NotificationParser().parse(mapPushData)
   }
 
-  private fun buildPushDataMap(mapPushData: Map<String, Any?>): Map<String, Any?> {
-    return mapOf(
-      "title" to mapPushData["title"],
-      "body" to mapPushData["body"],
-      "additionalData" to mapPushData
-    )
-  }
+  private fun bundleToMap(extras: Bundle): Map<String, Any?> {
 
-  private fun bundleToMap(extras: Bundle): Map<String, String?> {
-
-    val map: MutableMap<String, String?> = HashMap()
+    val map: MutableMap<String, Any?> = HashMap()
     val keySetValue = extras.keySet()
     val iterator: Iterator<String> = keySetValue.iterator()
     while (iterator.hasNext()) {
       val key = iterator.next()
-      map[key] = extras.getString(key)
+      map[key] = extras[key]
     }
+    
     return map
   }
 }

--- a/android/src/main/kotlin/com/lahaus/iterable_flutter/NotificationParser.kt
+++ b/android/src/main/kotlin/com/lahaus/iterable_flutter/NotificationParser.kt
@@ -10,22 +10,22 @@ class NotificationParser {
     return buildSendPushMap(mapPushData)
   }
 
-  private fun getAllFormatInt(dataPush: Map<String, Any?>): Map<String, Any?>{
+  private fun getAllFormatInt(dataPush: Map<String, Any?>): Map<String, Any?> {
     val map: MutableMap<String, Any?> = HashMap()
     for ((key, value) in dataPush) {
 
-      if(value is String){
+      if (value is String) {
 
-        if(value.intOrString() is Int){
+        if (value.toIntOrNull() != null) {
           val newValueInt: Int = value.toInt();
           map[key] = newValueInt;
-        }else{
+        } else {
           map[key] = value;
         }
       }
 
     }
-    return  map;
+    return map;
   }
 
   private fun buildSendPushMap(mapPushData: Map<String, Any?>): Map<String, Any?> {
@@ -36,11 +36,4 @@ class NotificationParser {
     )
   }
 
-}
-
-
-fun String.intOrString() = try { // returns Any
-  toInt()
-} catch(e: NumberFormatException) {
-  this
 }

--- a/android/src/main/kotlin/com/lahaus/iterable_flutter/NotificationParser.kt
+++ b/android/src/main/kotlin/com/lahaus/iterable_flutter/NotificationParser.kt
@@ -13,9 +13,7 @@ class NotificationParser {
   private fun getAllFormatInt(dataPush: Map<String, Any?>): Map<String, Any?> {
     val map: MutableMap<String, Any?> = HashMap()
     for ((key, value) in dataPush) {
-
       if (value is String) {
-
         if (value.toIntOrNull() != null) {
           val newValueInt: Int = value.toInt();
           map[key] = newValueInt;

--- a/android/src/main/kotlin/com/lahaus/iterable_flutter/NotificationParser.kt
+++ b/android/src/main/kotlin/com/lahaus/iterable_flutter/NotificationParser.kt
@@ -1,0 +1,46 @@
+package com.lahaus.iterable_flutter
+
+import java.util.HashMap
+
+class NotificationParser {
+
+  fun parse(dataPush: Map<String, Any?>): Map<String, Any?> {
+
+    val mapPushData = getAllFormatInt(dataPush)
+    return buildSendPushMap(mapPushData)
+  }
+
+  private fun getAllFormatInt(dataPush: Map<String, Any?>): Map<String, Any?>{
+    val map: MutableMap<String, Any?> = HashMap()
+    for ((key, value) in dataPush) {
+
+      if(value is String){
+
+        if(value.intOrString() is Int){
+          val newValueInt: Int = value.toInt();
+          map[key] = newValueInt;
+        }else{
+          map[key] = value;
+        }
+      }
+
+    }
+    return  map;
+  }
+
+  private fun buildSendPushMap(mapPushData: Map<String, Any?>): Map<String, Any?> {
+    return mapOf(
+      "title" to mapPushData["title"],
+      "body" to mapPushData["body"],
+      "additionalData" to mapPushData
+    )
+  }
+
+}
+
+
+fun String.intOrString() = try { // returns Any
+  toInt()
+} catch(e: NumberFormatException) {
+  this
+}

--- a/android/src/test/java/com/lahaus/iterable_flutter/MockData.kt
+++ b/android/src/test/java/com/lahaus/iterable_flutter/MockData.kt
@@ -1,0 +1,80 @@
+package com.lahaus.iterable_flutter
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.json.JSONTokener
+
+class MockData {
+
+  fun getMapTest() :  Map<String, Any>{
+    val json = """
+    {
+      "body": "IterableFlutterExamplePushContents",
+      "itbl": {
+      "defaultAction": {
+      "type": "openApp"
+    },
+      "isGhostPush": false,
+      "messageId": "c3d5233fab1c448abd27cfc5d6661239",
+      "actionButtons": [
+
+      ],
+      "templateId": 3758351
+    },
+      "name": "Santi",
+      "type": "test",
+      "real_estate_id": "344427",
+      "title": "IterableFlutterExamplePush"
+    }
+    """
+
+    return  jsonStringToBundle(json)
+
+  }
+
+  fun jsonStringToBundle(jsonString: String):  Map<String, Any> {
+
+      val jsonObject = toJsonObject(jsonString)
+      return toMap(jsonObject)
+
+  }
+
+  fun toJsonObject(jsonString: String?): JSONObject {
+
+    val jsonObject = JSONTokener(jsonString).nextValue() as JSONObject
+
+    return jsonObject
+  }
+
+  fun toMap(jsonobj: JSONObject): Map<String, Any> {
+    val map: MutableMap<String, Any> = HashMap()
+    val keys = jsonobj.keys()
+    while (keys.hasNext()) {
+      val key = keys.next()
+      var value = jsonobj[key]
+      if (value is JSONArray) {
+        value = toList(value as JSONArray)
+      } else if (value is JSONObject) {
+        value = toMap(value)
+      }
+      map[key] = value
+    }
+    return map
+  }
+
+
+  fun toList(array: JSONArray): List<Any> {
+    val list: MutableList<Any> = ArrayList()
+    for (i in 0 until array.length()) {
+      var value: Any = array.get(i)
+      if (value is JSONArray) {
+        value = toList(value as JSONArray)
+      } else if (value is JSONObject) {
+        value = toMap(value)
+      }
+      list.add(value)
+    }
+    return list
+  }
+
+}

--- a/android/src/test/java/com/lahaus/iterable_flutter/NotificationParserTest.kt
+++ b/android/src/test/java/com/lahaus/iterable_flutter/NotificationParserTest.kt
@@ -1,0 +1,46 @@
+package com.lahaus.iterable_flutter
+
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.Before
+
+class NotificationParserTest {
+
+  private lateinit var notificationParser: NotificationParser
+  private lateinit var  testMap:Map<String, Any?>
+
+  @Before
+  fun setup(){
+    notificationParser = NotificationParser()
+    testMap = MockData().getMapTest()
+  }
+
+  @Test
+  fun`parser function returns first node of the map the title of the push`() {
+
+    val result = notificationParser.parse(testMap);
+
+    assertEquals(result["title"], "IterableFlutterExamplePush")
+  }
+
+  @Test
+  fun`parser function returns in additionalData node of the map`() {
+
+    val result = notificationParser.parse(testMap);
+
+    val mapData = result["additionalData"] as Map<String, Any?>
+
+    assertEquals(mapData["type"], "test")
+    assertEquals(mapData["name"], "Santi")
+  }
+
+  @Test
+  fun`parser function returns map  whit values of integer type`() {
+
+    val result = notificationParser.parse(testMap);
+
+    val mapData = result["additionalData"] as Map<String, Any?>
+
+    assertEquals(mapData["real_estate_id"], 344427)
+  }
+}


### PR DESCRIPTION
what this PR:

- Homogeneity of data types
- Parser  String numeric to Integer 


## Issues encountered with iterable android SDK

It happens that when Iterable push arrives, it saves them in a map with String type key and String type Value, this makes it inconsistent with IOS.

I show where this is done in Iterable api:

**terableFirebaseMessagingService**
https://github.com/Iterable/iterable-android-sdk/blob/b7815ca6a02a6fb3fe14d160aa539e563ca1180e/iterableapi/src/main/java/com/iterable/iterableapi/IterableFirebaseMessagingService.java#L39-57

**IterableNotificationHelper**
https://github.com/Iterable/iterable-android-sdk/blob/b7815ca6a02a6fb3fe14d160aa539e563ca1180e/iterableapi/src/main/java/com/iterable/iterableapi/IterableNotificationHelper.java#L84


# Unit test
It is only tested that numeric String can be correctly transformed to integers and ensure that the map of values is sent correctly, this is tested since it is important logic for the homogeneity between  `IOS`

**Nota:** No test is carried out with the Bundle type data since it is typical of Android and the tests are complicated, with the aforementioned tests will be carried out from a map.









