### PR TITLE
ci(Test Action): avoid redundant jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,18 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Dart
+name: Test
 
 on:
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+
+# Cancel jobs and just run the last one
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  unit_test:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR will improve the tests job with:
- More descriptive name of the task running
- Canceling redundant jobs

# Current
If we push 3 times it will run 3 times every job

# Expected
If we push 3 times the old jobs are canceled and just run the last one