### PR TITLE
feat(registerForPush) Implementing registerForPush on iOS

### DIFF
--- a/ios/Classes/SwiftIterableFlutterPlugin.swift
+++ b/ios/Classes/SwiftIterableFlutterPlugin.swift
@@ -51,6 +51,10 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
             }
 
             result(nil)
+        case "registerForPush":
+            registerForPushNotifications()
+
+            result(nil)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -73,7 +77,6 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
     
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
         UNUserNotificationCenter.current().delegate = self
-        registerForPushNotifications()
         
         return true
     }

--- a/test/iterable_flutter_test.dart
+++ b/test/iterable_flutter_test.dart
@@ -136,9 +136,9 @@ void main() {
   });
 
   test('updateUser', () async {
-    await IterableFlutter.updateUser(params);
+    await IterableFlutter.updateUser(params: {});
     expect(calledMethod, <Matcher>[
-      isMethodCall('updateUser', arguments: params),
+      isMethodCall('updateUser', arguments: {"params": {}}),
     ]);
   });
 }


### PR DESCRIPTION
## What
Implementing (unused) registerForPush function on iOS

## Why
Currently, the registerForPush function is called automatically on `didFinishLaunchingWithOptions` which isn't always the best place. Most of the time you want to ask for permission during a custom flow, so my proposal is to stop calling that function automatically and leave it up to the developer to call it at the appropriate time.

## BREAKING CHANGE
Any app that lets the registerForPush function be called automatically would need to call it manually now.