### PR TITLE
fix(Last Push Payload): when you open the app, reload the latest data from the push notification

### DIFF
--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -62,7 +62,6 @@ class IterableFlutter {
   // ignore: use_setters_to_change_properties
   static void setNotificationOpenedHandler(OpenedNotificationHandler handler) {
     _onOpenedNotification = handler;
-    checkRecentNotification();
   }
 
   static Future<dynamic> nativeMethodCallHandler(MethodCall methodCall) async {

--- a/test/iterable_flutter_test.dart
+++ b/test/iterable_flutter_test.dart
@@ -103,7 +103,7 @@ void main() {
   });
 
   test('checkRecentNotification', () async {
-    IterableFlutter.setNotificationOpenedHandler((openedResultMap) {});
+    await IterableFlutter.checkRecentNotification();
     expect(calledMethod, <Matcher>[
       isMethodCall('checkRecentNotification', arguments: null),
     ]);


### PR DESCRIPTION
This will PR:

✅  Removes the checkRecentNotification from setNotificationOpenedHandler.
✅  Adjust unit test for checkRecentNotification.


issue open by @Gabriel-Azevedo  on https://github.com/la-haus/iterable-flutter/issues/35, since checkRecentNotification is called every time the app is opened (setNotificationOpenedHandler), even if the user already saw the push, every subsequent app open will trigger the push notification received flow.

Co-authored-by: @Gabriel-Azevedo . 
