### PR TITLE
fix(Open Push IOS): could not read push data when app was closed.

### DIFF
--- a/ios/Classes/SwiftIterableFlutterPlugin.swift
+++ b/ios/Classes/SwiftIterableFlutterPlugin.swift
@@ -3,7 +3,8 @@ import UIKit
 import IterableSDK
 import UserNotifications
 
-public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterDelegate {
+public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterDelegate, IterableCustomActionDelegate {
+   
     static var channel: FlutterMethodChannel? = nil
     
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -68,6 +69,7 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
         let config = IterableConfig()
         config.pushIntegrationName = pushIntegrationName
         config.autoPushRegistration = true
+        config.customActionDelegate = self
         
         IterableAPI.initialize(apiKey: apiKey, config: config)
     }
@@ -112,7 +114,11 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
                                        didReceive response: UNNotificationResponse,
                                        withCompletionHandler completionHandler: @escaping () -> Void) {
         IterableAppIntegration.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
+    }
+    
+    public func handle(iterableCustomAction action: IterableAction, inContext context: IterableActionContext) -> Bool {
         notifyPushNotificationOpened()
+        return true;
     }
 
     public func notifyPushNotificationOpened(){
@@ -137,3 +143,4 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
         
    }
 }
+


### PR DESCRIPTION
## Context

When you open a push notification and the app was closed, the push information could not be retrieved from Flutter, this only happened with IOS.

This bug is born from the solution of this [PR](https://github.com/la-haus/iterable-flutter/pull/42), since it eliminates the infinite loop but it was verified that it failed to open the push when the app was closed

## Note : 

> In order to read the push, it must be sent from a template since it has configured some types of push to be displayed

This will PR :

✅  Add `IterableCustomActionDelegate` to detect when open push and get data.
✅  Remove `notifyPushNotificationOpened` in `userNotificationCenter`.

# Current behavior
![2022-05-02 17 06 34](https://user-images.githubusercontent.com/12769042/166335849-c1efc106-1770-47a2-a7ce-d42f4d715c39.gif)

# Expected behavior
![2022-05-02 16 47 43](https://user-images.githubusercontent.com/12769042/166334889-5b9ca3dd-ca3b-450a-a320-ad2879418dbe.gif)

