### PR TITLE
feat(Data Push):  have a single delivery format of the push notification metadata. 🧾 

### DIFF
--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -68,7 +68,7 @@ class IterableFlutter {
 
   static Future<dynamic> nativeMethodCallHandler(MethodCall methodCall) async {
     final arguments = methodCall.arguments as Map<dynamic, dynamic>;
-    final argumentsCleaned = sanitizeMap(arguments,Platform.isAndroid);
+    final argumentsCleaned = sanitizeMap(arguments, Platform.isAndroid);
 
     switch (methodCall.method) {
       case "openedNotificationHandler":
@@ -79,16 +79,25 @@ class IterableFlutter {
     }
   }
 
-
-  static Map<String, dynamic> sanitizeMap(Map<dynamic, dynamic> mapDynamic, bool isAndroidPlatform) {
-    var mapHandleDynamic = mapDynamic;
+  static Map<String, dynamic> sanitizeMap(
+    Map<dynamic, dynamic> mapDynamic,
+    bool isAndroidPlatform,
+  ) {
+    final mapHandleDynamic = mapDynamic;
 
     if (isAndroidPlatform) {
-      mapHandleDynamic = _stringJsonToMap(mapDynamic as String);
+      final dataMap = mapHandleDynamic['additionalData'];
+      dataMap.forEach((key, value) {
+        if (value is String) {
+          if (value[0] == '{' && value[value.length - 1] == '}') {
+            dataMap[key] = _stringJsonToMap(value);
+          }
+        }
+      });
+      mapHandleDynamic['additionalData'] = dataMap;
     }
     return Map<String, dynamic>.from(mapHandleDynamic);
   }
-
 
   static Map<dynamic, dynamic> _stringJsonToMap(String stringJson) {
     final stringClean = stringJson.replaceAll('&quot;', '"');

--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -80,13 +80,13 @@ class IterableFlutter {
   }
 
   static Map<String, dynamic> sanitizeMap(
-    Map<dynamic, dynamic> mapDynamic,
+    Map<dynamic, dynamic> dynamicMap,
     bool isAndroidPlatform,
   ) {
-    final mapHandleDynamic = mapDynamic;
+    final dynamicMapHandler = dynamicMap;
 
     if (isAndroidPlatform) {
-      final dataMap = mapHandleDynamic['additionalData'];
+      final dataMap = dynamicMapHandler['additionalData'];
       dataMap.forEach((key, value) {
         if (value is String) {
           if (value[0] == '{' && value[value.length - 1] == '}') {
@@ -94,9 +94,9 @@ class IterableFlutter {
           }
         }
       });
-      mapHandleDynamic['additionalData'] = dataMap;
+      dynamicMapHandler['additionalData'] = dataMap;
     }
-    return Map<String, dynamic>.from(mapHandleDynamic);
+    return Map<String, dynamic>.from(dynamicMapHandler);
   }
 
   static Map<dynamic, dynamic> _stringJsonToMap(String stringJson) {

--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 
@@ -66,13 +68,31 @@ class IterableFlutter {
 
   static Future<dynamic> nativeMethodCallHandler(MethodCall methodCall) async {
     final arguments = methodCall.arguments as Map<dynamic, dynamic>;
+    final argumentsCleaned = sanitizeMap(arguments,Platform.isAndroid);
 
     switch (methodCall.method) {
       case "openedNotificationHandler":
-        _onOpenedNotification?.call(arguments);
+        _onOpenedNotification?.call(argumentsCleaned);
         return "This data from native.....";
       default:
         return "Nothing";
     }
+  }
+
+
+  static Map<String, dynamic> sanitizeMap(Map<dynamic, dynamic> mapDynamic, bool isAndroidPlatform) {
+    var mapHandleDynamic = mapDynamic;
+
+    if (isAndroidPlatform) {
+      mapHandleDynamic = _stringJsonToMap(mapDynamic as String);
+    }
+    return Map<String, dynamic>.from(mapHandleDynamic);
+  }
+
+
+  static Map<dynamic, dynamic> _stringJsonToMap(String stringJson) {
+    final stringClean = stringJson.replaceAll('&quot;', '"');
+
+    return jsonDecode(stringClean) as Map<dynamic, dynamic>;
   }
 }

--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -68,7 +68,7 @@ class IterableFlutter {
 
   static Future<dynamic> nativeMethodCallHandler(MethodCall methodCall) async {
     final arguments = methodCall.arguments as Map<dynamic, dynamic>;
-    final argumentsCleaned = sanitizeMap(arguments, Platform.isAndroid);
+    final argumentsCleaned = sanitizeArguments(arguments, Platform.isAndroid);
 
     switch (methodCall.method) {
       case "openedNotificationHandler":
@@ -79,24 +79,24 @@ class IterableFlutter {
     }
   }
 
-  static Map<String, dynamic> sanitizeMap(
-    Map<dynamic, dynamic> dynamicMap,
+  static Map<String, dynamic> sanitizeArguments(
+    Map<dynamic, dynamic> arguments,
     bool isAndroidPlatform,
   ) {
-    final dynamicMapHandler = dynamicMap;
+    final result = arguments;
 
     if (isAndroidPlatform) {
-      final dataMap = dynamicMapHandler['additionalData'];
-      dataMap.forEach((key, value) {
+      final data = result['additionalData'];
+      data.forEach((key, value) {
         if (value is String) {
           if (value[0] == '{' && value[value.length - 1] == '}') {
-            dataMap[key] = _stringJsonToMap(value);
+            data[key] = _stringJsonToMap(value);
           }
         }
       });
-      dynamicMapHandler['additionalData'] = dataMap;
+      result['additionalData'] = data;
     }
-    return Map<String, dynamic>.from(dynamicMapHandler);
+    return Map<String, dynamic>.from(result);
   }
 
   static Map<dynamic, dynamic> _stringJsonToMap(String stringJson) {

--- a/test/factories/push_notification_metadata_factories.dart
+++ b/test/factories/push_notification_metadata_factories.dart
@@ -1,0 +1,57 @@
+Map<dynamic, dynamic> buildPushNotificationMetadataAndroid() {
+  return {
+    'title': 'HiPush',
+    'body': 'test',
+    'additionalData': {
+      'keyMap':
+          "{\"keyMap2\":\"value2\",\"keyMap1\":\"value1\",\"keyMap4\":\"value4\"}",
+      'keyMapChild':
+          "{\"keyMapChild1\":\"value2\",\"keyMapChild2\":\"value3\",\"keyMapChild3\" "
+              ":{\"keyMapChild32\":\"value3\",\"keyMapChild31\":\"value2\",\"keyMapChild34\":\"value4\"}}",
+      'itbl': {
+        "defaultAction": {"type": "openApp"},
+        "isGhostPush": false,
+        "messageId": "messageIdValue",
+        "actionButtons": [],
+        "templateId": 10
+      },
+      'keyNumber': 1,
+      'body': 'test',
+      'title': 'HiPush',
+      'actionIdentifier': 'default',
+      'key': 'value1'
+    }
+  };
+}
+
+Map<dynamic, dynamic> buildPushNotificationMetadataIOS() {
+  return {
+    'title': 'HiPush',
+    'additionalData': {
+      'keyMap': {'keyMap1': 'value1', 'keyMap2': 'value2', 'keyMap4': 'value4'},
+      'itbl': {
+        'messageId': 'messageValue',
+        'defaultAction': {'type': 'openApp'},
+        'templateId': 10,
+        'actionButtons': [],
+        'isGhostPush': false
+      },
+      'keyMapChild': {
+        'keyMapChild3': {
+          'keyMapChild31': 'value2',
+          'keyMapChild32': 'value3',
+          'keyMapChild34': 'value4'
+        },
+        'keyMapChild2': 'value3',
+        'keyMapChild1': 'value2'
+      },
+      'key': 'value1',
+      'aps': {
+        'alert': {'title': 'HiPush', 'body': 'test'},
+        'interruption-level': 'active'
+      },
+      'keyNumber': 1
+    },
+    'body': 'test'
+  };
+}

--- a/test/iterable_flutter_test.dart
+++ b/test/iterable_flutter_test.dart
@@ -150,7 +150,7 @@ void main() {
 
         final additionalData = buildPushNotificationMetadataAndroid();
 
-        final result = IterableFlutter.sanitizeMap(additionalData, true);
+        final result = IterableFlutter.sanitizeArguments(additionalData, true);
 
         expect(result['body'], 'test');
         expect(result['additionalData']['keyNumber'] as int, 1);
@@ -167,7 +167,7 @@ void main() {
 
         final additionalData = buildPushNotificationMetadataIOS();
 
-        final result = IterableFlutter.sanitizeMap(additionalData, false);
+        final result = IterableFlutter.sanitizeArguments(additionalData, false);
 
         expect(result['body'], 'test');
         expect(result['additionalData']['keyNumber'] as int, 1);

--- a/test/iterable_flutter_test.dart
+++ b/test/iterable_flutter_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:iterable_flutter/iterable_flutter.dart';
 
+import 'factories/push_notification_metadata_factories.dart';
+
 void main() {
   final calledMethod = <MethodCall>[];
 
@@ -140,5 +142,40 @@ void main() {
     expect(calledMethod, <Matcher>[
       isMethodCall('updateUser', arguments: {"params": {}}),
     ]);
+  });
+
+  group('.sanitizeMap', () {
+    group('when metadata comes from Android', () {
+      test('should return a clear map', () {
+
+        final additionalData = buildPushNotificationMetadataAndroid();
+
+        final result = IterableFlutter.sanitizeMap(additionalData, true);
+
+        expect(result['body'], 'test');
+        expect(result['additionalData']['keyNumber'] as int, 1);
+        expect(result['additionalData']['keyMap']['keyMap2'], 'value2');
+        expect(result['additionalData']['keyMapChild']['keyMapChild3']['keyMapChild32'], 'value3');
+        expect(result['additionalData']['itbl']['isGhostPush'] as bool, isFalse);
+        expect(result['additionalData']['itbl']['defaultAction']['type'], 'openApp');
+      });
+    });
+
+
+    group('when metadata comes from iOS', () {
+      test('should return a clear map', () {
+
+        final additionalData = buildPushNotificationMetadataIOS();
+
+        final result = IterableFlutter.sanitizeMap(additionalData, false);
+
+        expect(result['body'], 'test');
+        expect(result['additionalData']['keyNumber'] as int, 1);
+        expect(result['additionalData']['keyMap']['keyMap2'], 'value2');
+        expect(result['additionalData']['keyMapChild']['keyMapChild3']['keyMapChild32'], 'value3');
+        expect(result['additionalData']['itbl']['isGhostPush'] as bool, isFalse);
+        expect(result['additionalData']['itbl']['defaultAction']['type'], 'openApp');
+      });
+    });
   });
 }


### PR DESCRIPTION
## Context

It happens that to read the push metadata, the structure was different for each platform.

## Solution 

In this will PR  contains a push read to formalize the structure before sending the clients


This will PR

✅  add a `sanitizeMap` method for formalize the structure.
✅. Unit test for each platforms. 🤓 


## No Changes in iOS

> In iOS yeas sends the data correctly 

## Breaking changes 🔥 

> This functionality breaks the metadata reading that is currently being done in Android 🔥 



## Current behavior 

Android 

![image (41)](https://user-images.githubusercontent.com/12769042/166716367-0f34ef7f-547c-4513-b255-3480df781618.png)
<details>
  <summary>Show map complete!</summary>

  ```dart
      {
        title: HiPush,
        body: test,
        additionalData: {
          keyMap: {
            "keyMap2": "value3",
            "keyMap1": "value2",
            "keyMap4": "value4"
          },
          keyMapChild: {
            "keyMapChild1": "value2",
            "keyMapChild2": "value3",
            "keyMapChild3": {
              "keyMapChild32": "value3",
              "keyMapChild31": "value2",
              "keyMapChild34": "value4"
            }
          },
          itbl: {
            "defaultAction": {
              "type": "openApp"
            },
            "isGhostPush": false,
            "messageId": "12",
            "actionButtons": [
              
            ],
            "templateId": 12
          },
          keyNumber: 1,
          body: test,
          title: HiPush,
          actionIdentifier: default,
          key: value1
        }
      }
```
</details>



## Expected behavior 

![image (42)](https://user-images.githubusercontent.com/12769042/166717330-b87d3be9-8490-4d10-b329-b56295aba5e4.png)

<details>
  <summary>Show map complete!</summary>
 
   ```dart
     {
      title: HiPush,
      body: test,
      additionalData: {
        keyMap: {
          keyMap2: value3,
          keyMap1: value2,
          keyMap4: value4
        },
        keyMapChild: {
          keyMapChild1: value2,
          keyMapChild2: value3,
          keyMapChild3: {
            keyMapChild32: value3,
            keyMapChild31: value2,
            keyMapChild34: value4
          }
        },
        itbl: {
          defaultAction: {
            type: openApp
          },
          isGhostPush: false,
          messageId: 123,
          actionButtons: [
            
          ],
          templateId: 12
        },
        keyNumber: 1,
        body: test,
        title: HiPush,
        actionIdentifier: default,
        key: value1
      }
    }
    ```
 </details>




