### PR TITLE
chore(Release): 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.5.4
+### Features
+- feat(Data Push): have a single delivery format of the push notification metadata. 🧾 #47.
+- feat(Library Pubspec): add pubspec to the ignore file by recommendation #43
+### Fix
+- Fix Crash on API 31+ #46.
+- fix(Open Push IOS): could not read push data when app was closed. #45
+- fix(Last Push Payload): when you open the app, reload the latest data from the push notification #42
+### Other work
+- ci(Android): fix ci builds for android #44
+
 ## 0.3.0+1
 Added to update pubspec info.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: iterable_flutter
 description: Flutter implementation for iterable.com Cross Channel Marketing Platform
-version: 0.3.0+1
+version: 0.5.4
 homepage: https://lahaus.com
 repository: https://github.com/la-haus/iterable-flutter
 issue_tracker: https://github.com/la-haus/iterable-flutter/issues


### PR DESCRIPTION
## Feat 

- [feat(Data Push): have a single delivery format of the push notification metadata. 🧾 #47](https://github.com/la-haus/iterable-flutter/pull/47). 
- [feat(Library Pubspec): add pubspec to the ignore file by recommendation #43](https://github.com/la-haus/iterable-flutter/pull/43)


## Fix

- [Fix Crash on API 31+ #46](https://github.com/la-haus/iterable-flutter/pull/46).
- [fix(Open Push IOS): could not read push data when app was closed. #45](https://github.com/la-haus/iterable-flutter/pull/45)
- [fix(Last Push Payload): when you open the app, reload the latest data from the push notification #42](https://github.com/la-haus/iterable-flutter/pull/42)

## Other work

- [ci(Android): fix ci builds for android #44](https://github.com/la-haus/iterable-flutter/pull/44)