### PR TITLE
fix(PayLoad Push): IOS SDK sends the push payload encoded sometimes

### DIFF
--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter/services.dart';
 
@@ -68,7 +67,7 @@ class IterableFlutter {
 
   static Future<dynamic> nativeMethodCallHandler(MethodCall methodCall) async {
     final arguments = methodCall.arguments as Map<dynamic, dynamic>;
-    final argumentsCleaned = sanitizeArguments(arguments, Platform.isAndroid);
+    final argumentsCleaned = sanitizeArguments(arguments);
 
     switch (methodCall.method) {
       case "openedNotificationHandler":
@@ -81,21 +80,19 @@ class IterableFlutter {
 
   static Map<String, dynamic> sanitizeArguments(
     Map<dynamic, dynamic> arguments,
-    bool isAndroidPlatform,
   ) {
     final result = arguments;
 
-    if (isAndroidPlatform) {
-      final data = result['additionalData'];
-      data.forEach((key, value) {
-        if (value is String) {
-          if (value[0] == '{' && value[value.length - 1] == '}') {
-            data[key] = _stringJsonToMap(value);
-          }
+    final data = result['additionalData'];
+    data.forEach((key, value) {
+      if (value is String) {
+        if (value[0] == '{' && value[value.length - 1] == '}') {
+          data[key] = _stringJsonToMap(value);
         }
-      });
-      result['additionalData'] = data;
-    }
+      }
+    });
+    result['additionalData'] = data;
+
     return Map<String, dynamic>.from(result);
   }
 

--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -79,8 +79,7 @@ class IterableFlutter {
   }
 
   static Map<String, dynamic> sanitizeArguments(
-    Map<dynamic, dynamic> arguments,
-  ) {
+      Map<dynamic, dynamic> arguments) {
     final result = arguments;
 
     final data = result['additionalData'];

--- a/test/factories/push_notification_metadata_factories.dart
+++ b/test/factories/push_notification_metadata_factories.dart
@@ -55,3 +55,29 @@ Map<dynamic, dynamic> buildPushNotificationMetadataIOS() {
     'body': 'test'
   };
 }
+
+Map<dynamic, dynamic> buildPushNotificationMetadataIOSWithQuot() {
+  return {
+    'title': 'HiPush',
+    'body': 'test',
+    'additionalData': {
+      'keyMap':
+      "{&quot;keyMap2&quot;:&quot;value2&quot;,&quot;keyMap1&quot;:&quot;value1&quot;,&quot;keyMap4&quot;:&quot;value4&quot;}",
+      'keyMapChild':
+      "{&quot;keyMapChild1&quot;:&quot;value2&quot;,&quot;keyMapChild2&quot;:&quot;value3&quot;,&quot;keyMapChild3&quot; "
+          ":{&quot;keyMapChild32&quot;:&quot;value3&quot;,&quot;keyMapChild31&quot;:&quot;value2&quot;,&quot;keyMapChild34&quot;:&quot;value4&quot;}}",
+      'itbl': {
+        "defaultAction": {"type": "openApp"},
+        "isGhostPush": false,
+        "messageId": "messageIdValue",
+        "actionButtons": [],
+        "templateId": 10
+      },
+      'keyNumber': 1,
+      'body': 'test',
+      'title': 'HiPush',
+      'actionIdentifier': 'default',
+      'key': 'value1'
+    }
+  };
+}

--- a/test/iterable_flutter_test.dart
+++ b/test/iterable_flutter_test.dart
@@ -15,7 +15,7 @@ void main() {
   const String userId = '11111';
   const String event = 'my_event';
 
-  const contentBody = { 'testKey' : "Test body push"};
+  const contentBody = {'testKey': "Test body push"};
   const keyBody = "additionalData";
 
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -147,7 +147,6 @@ void main() {
   group('.sanitizeMap', () {
     group('when metadata comes from Android', () {
       test('should return a clear map', () {
-
         final additionalData = buildPushNotificationMetadataAndroid();
 
         final result = IterableFlutter.sanitizeArguments(additionalData);
@@ -155,26 +154,56 @@ void main() {
         expect(result['body'], 'test');
         expect(result['additionalData']['keyNumber'] as int, 1);
         expect(result['additionalData']['keyMap']['keyMap2'], 'value2');
-        expect(result['additionalData']['keyMapChild']['keyMapChild3']['keyMapChild32'], 'value3');
-        expect(result['additionalData']['itbl']['isGhostPush'] as bool, isFalse);
-        expect(result['additionalData']['itbl']['defaultAction']['type'], 'openApp');
+        expect(
+            result['additionalData']['keyMapChild']['keyMapChild3']
+                ['keyMapChild32'],
+            'value3');
+        expect(
+            result['additionalData']['itbl']['isGhostPush'] as bool, isFalse);
+        expect(result['additionalData']['itbl']['defaultAction']['type'],
+            'openApp');
       });
     });
 
-
     group('when metadata comes from iOS', () {
-      test('should return a clear map', () {
+      group('when payload arrives clean', () {
+        test('should return a clear map', () {
+          final additionalData = buildPushNotificationMetadataIOS();
 
-        final additionalData = buildPushNotificationMetadataIOS();
+          final result = IterableFlutter.sanitizeArguments(additionalData);
 
-        final result = IterableFlutter.sanitizeArguments(additionalData);
+          expect(result['body'], 'test');
+          expect(result['additionalData']['keyNumber'] as int, 1);
+          expect(result['additionalData']['keyMap']['keyMap2'], 'value2');
+          expect(
+              result['additionalData']['keyMapChild']['keyMapChild3']
+                  ['keyMapChild32'],
+              'value3');
+          expect(
+              result['additionalData']['itbl']['isGhostPush'] as bool, isFalse);
+          expect(result['additionalData']['itbl']['defaultAction']['type'],
+              'openApp');
+        });
+      });
 
-        expect(result['body'], 'test');
-        expect(result['additionalData']['keyNumber'] as int, 1);
-        expect(result['additionalData']['keyMap']['keyMap2'], 'value2');
-        expect(result['additionalData']['keyMapChild']['keyMapChild3']['keyMapChild32'], 'value3');
-        expect(result['additionalData']['itbl']['isGhostPush'] as bool, isFalse);
-        expect(result['additionalData']['itbl']['defaultAction']['type'], 'openApp');
+      group('when payload does not arrives clean', () {
+        test('should return a clear map', () {
+          final additionalData = buildPushNotificationMetadataIOSWithQuot();
+
+          final result = IterableFlutter.sanitizeArguments(additionalData);
+
+          expect(result['body'], 'test');
+          expect(result['additionalData']['keyNumber'] as int, 1);
+          expect(result['additionalData']['keyMap']['keyMap2'], 'value2');
+          expect(
+              result['additionalData']['keyMapChild']['keyMapChild3']
+                  ['keyMapChild32'],
+              'value3');
+          expect(
+              result['additionalData']['itbl']['isGhostPush'] as bool, isFalse);
+          expect(result['additionalData']['itbl']['defaultAction']['type'],
+              'openApp');
+        });
       });
     });
   });

--- a/test/iterable_flutter_test.dart
+++ b/test/iterable_flutter_test.dart
@@ -15,8 +15,8 @@ void main() {
   const String userId = '11111';
   const String event = 'my_event';
 
-  const contentBody = "Test body push";
-  const keyBody = "body";
+  const contentBody = { 'testKey' : "Test body push"};
+  const keyBody = "additionalData";
 
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -150,7 +150,7 @@ void main() {
 
         final additionalData = buildPushNotificationMetadataAndroid();
 
-        final result = IterableFlutter.sanitizeArguments(additionalData, true);
+        final result = IterableFlutter.sanitizeArguments(additionalData);
 
         expect(result['body'], 'test');
         expect(result['additionalData']['keyNumber'] as int, 1);
@@ -167,7 +167,7 @@ void main() {
 
         final additionalData = buildPushNotificationMetadataIOS();
 
-        final result = IterableFlutter.sanitizeArguments(additionalData, false);
+        final result = IterableFlutter.sanitizeArguments(additionalData);
 
         expect(result['body'], 'test');
         expect(result['additionalData']['keyNumber'] as int, 1);


### PR DESCRIPTION
# Bug 
In some cases IOS can also send the objects as a string this makes the reading fail.

![image (43)](https://user-images.githubusercontent.com/12769042/167903184-24a570e1-9fb4-4477-9df1-0f09946fd325.png)

# Solution
For this solution, it was left that if it is detected in any child of payload, a string with the characteristics of a json will return it to a map.


## What was done

I only remove param `isAndroidPlatform` for this case always into the logic for detect that if value has content a json string.

## Expected behavior
 
![image (44)](https://user-images.githubusercontent.com/12769042/167904536-f5c1a916-22a1-4137-9ce6-6bd97fe2d78a.png)


