### PR TITLE
Chore: Add support for Iterable Push notifications with `Open URL` open action behaviour on iOS. 

### DIFF
--- a/ios/Classes/SwiftIterableFlutterPlugin.swift
+++ b/ios/Classes/SwiftIterableFlutterPlugin.swift
@@ -147,7 +147,7 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
         let payload = [
             "title": alertInfo["title"] ?? "",
             "body": alertInfo["body"] ?? "",
-            "additionalData": IterableAPI.lastPushPayload!
+            "additionalData": userInfo
         ] as [String : Any]
         
         SwiftIterableFlutterPlugin.channel?.invokeMethod("openedNotificationHandler", arguments: payload)

--- a/ios/Classes/SwiftIterableFlutterPlugin.swift
+++ b/ios/Classes/SwiftIterableFlutterPlugin.swift
@@ -130,25 +130,21 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
     }
 
     public func notifyPushNotificationOpened(){
-        let userInfo = IterableAPI.lastPushPayload
-        
-        if(userInfo != nil){
-            let apsInfo = userInfo!["aps"] as? [String: AnyObject]
-            let alertInfo = apsInfo?["alert"] as? [String: AnyObject]
-            
-            if(alertInfo != nil){
-                
-                let payload = [
-                    "title": alertInfo?["title"] ?? "",
-                    "body": alertInfo?["body"] ?? "",
-                    "additionalData": IterableAPI.lastPushPayload!
-                ] as [String : Any]
-                
-                SwiftIterableFlutterPlugin.channel?.invokeMethod("openedNotificationHandler", arguments: payload)
-            }
-            
+        guard let userInfo = IterableAPI.lastPushPayload,
+              let apsInfo = userInfo["aps"] as? [String: AnyObject],
+              let alertInfo = apsInfo["alert"] as? [String: AnyObject]
+        else {
+            return
         }
         
-   }
+        let payload = [
+            "title": alertInfo["title"] ?? "",
+            "body": alertInfo["body"] ?? "",
+            "additionalData": IterableAPI.lastPushPayload!
+        ] as [String : Any]
+        
+        SwiftIterableFlutterPlugin.channel?.invokeMethod("openedNotificationHandler", arguments: payload)
+        
+    }
+    
 }
-

--- a/ios/Classes/SwiftIterableFlutterPlugin.swift
+++ b/ios/Classes/SwiftIterableFlutterPlugin.swift
@@ -3,7 +3,7 @@ import UIKit
 import IterableSDK
 import UserNotifications
 
-public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterDelegate, IterableCustomActionDelegate {
+public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotificationCenterDelegate, IterableCustomActionDelegate, IterableURLDelegate {
    
     static var channel: FlutterMethodChannel? = nil
     
@@ -78,6 +78,7 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
         config.pushIntegrationName = pushIntegrationName
         config.autoPushRegistration = true
         config.customActionDelegate = self
+        config.urlDelegate = self
         
         IterableAPI.initialize(apiKey: apiKey, config: config)
     }
@@ -129,6 +130,12 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
         return true;
     }
 
+    
+    public func handle(iterableURL url: URL, inContext context: IterableActionContext) -> Bool {
+        notifyPushNotificationOpened()
+        return true
+    }
+    
     public func notifyPushNotificationOpened(){
         guard let userInfo = IterableAPI.lastPushPayload,
               let apsInfo = userInfo["aps"] as? [String: AnyObject],


### PR DESCRIPTION
## What it does
- Makes `SwiftIterableFlutterPlugin` class conform to the `IterableURLDelegate` protocol so that it can receive and propagate Iterable push notifications that are configured with the "Open URL" action.
  - With this change in place, the `openedNotificationHandler` in the Flutter application will now also be called for Iterable push notifications that are set-up in Iterable as having the Open action behaviour type set to "Open URL".
Prior to this change, the Flutter application would not be called when configured as "Open URL" so deep-link use cases were not supported.

## How to test (Unit test)
1. From the command line, run the unit tests :- `$ flutter test`.
2. Observe that the result of running the tests contains the following line: `All tests passed!`

## How to test (iOS)
Having configured the application as per `iterable_flutter` instructions, and with the `openedNotificationHandler` also set in your Flutter code :-

1. Login to Iterable's website and create an Iterable Push notification campaign with the `Open action` behaviour set to "Open URL". 
![SCR-20230821-isrj-2](https://github.com/la-haus/iterable-flutter/assets/302881/d3e714cc-4a41-4617-8b5c-8ccbf274f9ee)
3. Save the campaign changes.
4. Tap the "Send test message" button, to send the push notification to a specified user/device. 
![SCR-20230821-itkk-2](https://github.com/la-haus/iterable-flutter/assets/302881/808f1f88-b4d1-4812-bf50-16074fe0ddc8)
6. Observe that your `openedNotificationHandler` is called with the url specified in the campaign as follows :-

```json
{
	"title": "...",
	"body": "...",
	"additionalData": {
		"itbl": {
			"messageId": "",
			"defaultAction": {
				"type": "openUrl",
				"data": "https://example.com/your/path/here?a=b"
			},
			"aps": {}
		},
		"url": "https://example.com/your/path/here?a=b"
	}
}
```

## Notes:
- When received on Android, it was observed that the `additionalData.url` key was actually `additionalData.uri`.
- For safety, simply use the key `additionalData.itbl.defaultAction.data`, to retrieve the url (although on Android, this seems to be delivered as a **`JSON` string**, rather than an a `Dictionary`/`Map`/`Associative array`).