### PR TITLE
GH-62: adding jwt-enabled API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 example/ios/Podfile.lock
 example/pubspec.lock
+.dart_tool/
+build/
+pubspec.lock

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,10 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'com.iterable:iterableapi:3.4.9'
+    implementation 'com.iterable:iterableapi:3.4.15'
+    implementation 'com.iterable:iterableapi-ui:3.4.0' 
+    // Version 17.4.0+ is required for push notifications and in-app message features:
+    implementation 'com.google.firebase:firebase-messaging:17.4.0' 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.json:json:20210307'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.lahaus.iterable_flutter">
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 </manifest>

--- a/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
@@ -15,6 +15,8 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import org.json.JSONObject
 import java.util.*
+import java.net.URL
+
 
 
 /** IterableFlutterPlugin */
@@ -92,6 +94,14 @@ class IterableFlutterPlugin : FlutterPlugin, MethodCallHandler {
         var userInfo = call.argument<Map<String, Any>?>("params")
         IterableApi.getInstance().updateUser(JSONObject(userInfo))
         result.success(null)
+      }
+      "handleDeepLink" -> {
+        val argumentData = call.arguments as? Map<*, *>
+        val url = argumentData?.get("url") as String
+        IterableApi.getInstance().getAndTrackDeepLink(url) { result:String? ->
+            Log.d("HandleDeeplink", "Redirected to: $result")
+            channel.invokeMethod("deepLinkHandler", mapOf("path" to URL(result).path))
+        }
       }
       else -> {
         result.notImplemented()

--- a/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/lahaus/iterable_flutter/IterableFlutterPlugin.kt
@@ -52,9 +52,9 @@ class IterableFlutterPlugin : FlutterPlugin, MethodCallHandler {
         result.success(null)
       }
       "setEmail" -> {
-        val userEmail = call.arguments as String
-        IterableApi.getInstance().setEmail(userEmail)
-        IterableApi.getInstance().registerForPush()
+        val email = call.argument<String>("email") ?: ""
+        val jwt = call.argument<String>("jwt") ?: ""
+        IterableApi.getInstance().setEmail(email, jwt)
         result.success(null)
       }
       "setUserId" -> {
@@ -107,11 +107,10 @@ class IterableFlutterPlugin : FlutterPlugin, MethodCallHandler {
         notifyPushNotificationOpened()
         false
       }
-
+    
     if (activeLogDebug) {
-      configBuilder.setLogLevel(Log.DEBUG)
+      configBuilder.setLogLevel(Log.VERBOSE)
     }
-
     IterableApi.initialize(context, apiKey, configBuilder.build())
   }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -29,7 +29,7 @@ apply from: project(':flutter_config').projectDir.getPath() + "/dotenv.gradle"
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -39,7 +39,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.lahaus.iterable_flutter_example"
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/ios/Classes/SwiftIterableFlutterPlugin.swift
+++ b/ios/Classes/SwiftIterableFlutterPlugin.swift
@@ -23,6 +23,10 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
         completion(token)
     }
 
+    public func onAuthFailure(_ authFailure: AuthFailure) {
+        
+    }
+
     public func onTokenRegistrationFailed(_ reason: String?) {
         print("token registration failed")
         print(reason)

--- a/ios/Classes/SwiftIterableFlutterPlugin.swift
+++ b/ios/Classes/SwiftIterableFlutterPlugin.swift
@@ -151,7 +151,11 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
 
     
     public func handle(iterableURL url: URL, inContext context: IterableActionContext) -> Bool {
-        notifyPushNotificationOpened()
+        let payload = [
+            "path": url.path ?? ""
+        ] as [String : Any]
+
+        SwiftIterableFlutterPlugin.channel?.invokeMethod("deepLinkHandler", arguments: payload)
         return true
     }
     

--- a/ios/Classes/SwiftIterableFlutterPlugin.swift
+++ b/ios/Classes/SwiftIterableFlutterPlugin.swift
@@ -163,6 +163,7 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
         NSLog("deeplink \(url.path)")
         let payload = [
             "path": url.path ?? "",
+            "query": url.query ?? ""
         ] as [String : Any]
         NSLog("calling deepLinkHandler up the channel")
         NSLog("is there a channel? \(SwiftIterableFlutterPlugin.channel == nil)")

--- a/ios/Classes/SwiftIterableFlutterPlugin.swift
+++ b/ios/Classes/SwiftIterableFlutterPlugin.swift
@@ -27,8 +27,10 @@ public class SwiftIterableFlutterPlugin: NSObject, FlutterPlugin, UNUserNotifica
             
             result(nil)
         case "setEmail":
-            let email = call.arguments as! String
-            IterableAPI.email = email
+            let args = getPropertiesFromArguments(call.arguments)
+            let email = args["email"] as! String
+            let jwt = args["jwt"] as! String
+            IterableAPI.setEmail(email, jwt)
             
             result(nil)
         case "setUserId":

--- a/ios/iterable_flutter.podspec
+++ b/ios/iterable_flutter.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Iterable-iOS-SDK', '6.4.15'
+  s.dependency 'Iterable-iOS-SDK', '6.5.5'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/iterable_flutter.podspec
+++ b/ios/iterable_flutter.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Iterable-iOS-SDK', '6.5.5'
+  s.dependency 'Iterable-iOS-SDK', '6.5.7'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/iterable_flutter.podspec
+++ b/ios/iterable_flutter.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Iterable-iOS-SDK', '6.4.7'
+  s.dependency 'Iterable-iOS-SDK', '6.4.15'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -4,12 +4,14 @@ import 'dart:convert';
 import 'package:flutter/services.dart';
 
 typedef OpenedNotificationHandler = void Function(Map openedResult);
+typedef OpenedDeepLinkHandler = void Function(Map openedResult);
 
 // ignore: avoid_classes_with_only_static_members
 class IterableFlutter {
   static const MethodChannel _channel = MethodChannel('iterable_flutter');
 
   static OpenedNotificationHandler? _onOpenedNotification;
+  static OpenedDeepLinkHandler? _onOpenedDeepLink;
 
   static Future<void> initialize({
     required String apiKey,
@@ -77,6 +79,10 @@ class IterableFlutter {
     _onOpenedNotification = handler;
   }
 
+  static void setDeepLinkOpenedHandler(OpenedDeepLinkHandler handler) {
+    _onOpenedDeepLink = handler;
+  }
+
   static Future<dynamic> nativeMethodCallHandler(MethodCall methodCall) async {
     final arguments = methodCall.arguments as Map<dynamic, dynamic>;
     final argumentsCleaned = sanitizeArguments(arguments);
@@ -85,6 +91,9 @@ class IterableFlutter {
       case "openedNotificationHandler":
         _onOpenedNotification?.call(argumentsCleaned);
         return "This data from native.....";
+      case "deepLinkHandler":
+        _onOpenedDeepLink?.call(argumentsCleaned);
+        return "Deep link datta from handler...";
       default:
         return "Nothing";
     }

--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -16,16 +16,14 @@ class IterableFlutter {
   static Future<void> initialize({
     required String apiKey,
     required String pushIntegrationName,
-    bool activeLogDebug = false,
-    String? authToken = null
+    bool activeLogDebug = false
   }) async {
     await _channel.invokeMethod(
       'initialize',
       {
         'apiKey': apiKey,
         'pushIntegrationName': pushIntegrationName,
-        'activeLogDebug': activeLogDebug,
-        'authToken': authToken
+        'activeLogDebug': activeLogDebug
       },
     );
     _channel.setMethodCallHandler(nativeMethodCallHandler);
@@ -39,6 +37,12 @@ class IterableFlutter {
         'jwt': jwt,
       },
     );
+  }
+
+  static Future<void> handleDeepLink(url) async {
+    print("handleDeepLink");
+    print(url);
+    await _channel.invokeMethod("handleDeepLink", {'url': url});
   }
 
   static Future<void> setUserId(String userId) async {
@@ -80,18 +84,20 @@ class IterableFlutter {
   }
 
   static void setDeepLinkOpenedHandler(OpenedDeepLinkHandler handler) {
+    print("calling setDeepLinkOpenedHandler ");
     _onOpenedDeepLink = handler;
   }
 
   static Future<dynamic> nativeMethodCallHandler(MethodCall methodCall) async {
+    print("nativeMethodCallHandler maybe deep? ${methodCall.method}");
     final arguments = methodCall.arguments as Map<dynamic, dynamic>;
     final argumentsCleaned = sanitizeArguments(arguments);
-
     switch (methodCall.method) {
       case "openedNotificationHandler":
         _onOpenedNotification?.call(argumentsCleaned);
         return "This data from native.....";
       case "deepLinkHandler":
+        print("deepLinkHandler running... ");
         _onOpenedDeepLink?.call(argumentsCleaned);
         return "Deep link datta from handler...";
       default:
@@ -103,7 +109,7 @@ class IterableFlutter {
       Map<dynamic, dynamic> arguments) {
     final result = arguments;
 
-    final data = result['additionalData'];
+    final data = result['additionalData'] ?? {};
     data.forEach((key, value) {
       if (value is String) {
         if (value[0] == '{' && value[value.length - 1] == '}') {

--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -15,13 +15,15 @@ class IterableFlutter {
     required String apiKey,
     required String pushIntegrationName,
     bool activeLogDebug = false,
+    String? authToken = null
   }) async {
     await _channel.invokeMethod(
       'initialize',
       {
         'apiKey': apiKey,
         'pushIntegrationName': pushIntegrationName,
-        'activeLogDebug': activeLogDebug
+        'activeLogDebug': activeLogDebug,
+        'authToken': authToken
       },
     );
     _channel.setMethodCallHandler(nativeMethodCallHandler);

--- a/lib/iterable_flutter.dart
+++ b/lib/iterable_flutter.dart
@@ -27,8 +27,14 @@ class IterableFlutter {
     _channel.setMethodCallHandler(nativeMethodCallHandler);
   }
 
-  static Future<void> setEmail(String email) async {
-    await _channel.invokeMethod('setEmail', email);
+  static Future<void> setEmail(String email, String jwt) async {
+    await _channel.invokeMethod(
+      'setEmail',
+      {
+        'email': email,
+        'jwt': jwt,
+      },
+    );
   }
 
   static Future<void> setUserId(String userId) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: iterable_flutter
 description: Flutter implementation for iterable.com Cross Channel Marketing Platform
-version: 0.5.8
+version: 0.6.2
 homepage: https://lahaus.com
 repository: https://github.com/la-haus/iterable-flutter
 issue_tracker: https://github.com/la-haus/iterable-flutter/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: iterable_flutter
 description: Flutter implementation for iterable.com Cross Channel Marketing Platform
-version: 0.9.2
+version: 0.9.3
 homepage: https://lahaus.com
 repository: https://github.com/la-haus/iterable-flutter
 issue_tracker: https://github.com/la-haus/iterable-flutter/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: iterable_flutter
 description: Flutter implementation for iterable.com Cross Channel Marketing Platform
-version: 0.9.1
+version: 0.9.2
 homepage: https://lahaus.com
 repository: https://github.com/la-haus/iterable-flutter
 issue_tracker: https://github.com/la-haus/iterable-flutter/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: iterable_flutter
 description: Flutter implementation for iterable.com Cross Channel Marketing Platform
-version: 0.7.0
+version: 0.9.1
 homepage: https://lahaus.com
 repository: https://github.com/la-haus/iterable-flutter
 issue_tracker: https://github.com/la-haus/iterable-flutter/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: iterable_flutter
 description: Flutter implementation for iterable.com Cross Channel Marketing Platform
-version: 0.6.2
+version: 0.7.0
 homepage: https://lahaus.com
 repository: https://github.com/la-haus/iterable-flutter
 issue_tracker: https://github.com/la-haus/iterable-flutter/issues

--- a/test/iterable_flutter_test.dart
+++ b/test/iterable_flutter_test.dart
@@ -13,6 +13,7 @@ void main() {
   const String activeLogDebug = 'activeLogDebug';
   const String email = 'my@email.com';
   const String userId = '11111';
+  const String jwt = '';
   const String event = 'my_event';
   const Map<String, dynamic> dataFields = {'data': 'field'};
 
@@ -71,9 +72,12 @@ void main() {
   });
 
   test('setEmail', () async {
-    await IterableFlutter.setEmail(email);
+    await IterableFlutter.setEmail(email, jwt);
     expect(calledMethod, <Matcher>[
-      isMethodCall('setEmail', arguments: email),
+      isMethodCall('setEmail', arguments: {
+        "email": email,
+        "jwt": jwt
+      }),
     ]);
   });
 

--- a/test/iterable_flutter_test.dart
+++ b/test/iterable_flutter_test.dart
@@ -15,6 +15,7 @@ void main() {
   const String userId = '11111';
   const String jwt = '';
   const String event = 'my_event';
+  const String authToken = 'authToken';
   const Map<String, dynamic> dataFields = {'data': 'field'};
 
   const contentBody = {'testKey': "Test body push"};
@@ -65,7 +66,8 @@ void main() {
         arguments: {
           apiKey: apiKey,
           pushIntegrationName: pushIntegrationName,
-          activeLogDebug: false
+          activeLogDebug: false,
+          authToken: null
         },
       ),
     ]);


### PR DESCRIPTION
This PR aims to take advantage of the optional JWT 2nd parameter when calling `IterableFlutter.setEmail`. I'm not sure what PR etiquette looks like for your team, but I'd love any feedback you have on how I can improve the PR so we can get it merged & others can take advantage of this feature.

Credit @QoLTech for his [original inspiration for this PR](https://github.com/la-haus/iterable-flutter/pull/63). 