### PR TITLE
Bump ios package

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.lahaus.iterable_flutter"
     compileSdkVersion 31
 
     sourceSets {

--- a/ios/iterable_flutter.podspec
+++ b/ios/iterable_flutter.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Iterable-iOS-SDK', '6.4.7'
+  s.dependency 'Iterable-iOS-SDK', '6.6.1'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
bumping iterable ios sdk due to issue:
https://github.com/Iterable/iterable-swift-sdk/issues/844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Iterable-iOS-SDK dependency to version 6.6.1
  * Added namespace configuration to Android build settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->